### PR TITLE
fix(ci): silence mypy call-arg on pydantic-settings instantiation

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -19,4 +19,4 @@ class Settings(BaseSettings):
         return self.max_file_size_mb * 1024 * 1024
 
 
-settings = Settings()
+settings = Settings()  # type: ignore[call-arg]  # fields populated from env/.env


### PR DESCRIPTION
pydantic-settings populates required fields from the environment / .env, but mypy treats them as missing positional kwargs at the call site (`Settings()`). Suppress the specific code with a short inline comment explaining where the value actually comes from.

Found 1 error in 1 file → now passes `mypy app`.